### PR TITLE
Turn on metrics publishing

### DIFF
--- a/mama-prd/config.json
+++ b/mama-prd/config.json
@@ -7,7 +7,6 @@
   "custom_opening_copy": "Welcome to MAMA on Equity World. For free SMSes about your pregnancy, we need to ask you 3 questions.",
   "stk_fake_exit": true,
   "default_language" : "english",
-  "skip_holodeck": 1,
   "welcome_sms_copy": "",
   "extra_sms_stat_keys": [],
   "sequential_send_keys": [

--- a/mama-qa/config.json
+++ b/mama-qa/config.json
@@ -7,7 +7,6 @@
   "custom_opening_copy": "Welcome to MAMA. For free SMSes about your pregnancy, we need to ask you 3 questions.",
   "stk_fake_exit": true,
   "default_language": "english",
-  "skip_holodeck": 1,
   "welcome_sms_copy": "",
   "extra_sms_stat_keys": [],
   "conversation_metrics": [


### PR DESCRIPTION
The QA and production configs both have `skip_holodeck: 1`. Unfortunately `skip_holodeck` actually skips all metrics publishing (presumably the name is a legacy one from when metrics were published to holodeck).

See https://github.com/praekelt/mama-sms/blob/develop/go-app-default.js#L110-L112
